### PR TITLE
fix: Set default val for 'Pizzas' property to null

### DIFF
--- a/PizzaStore/PizzaDb.cs
+++ b/PizzaStore/PizzaDb.cs
@@ -6,7 +6,7 @@ namespace PizzaStore.Data;
 public class PizzaDb : DbContext
 {
     public PizzaDb(DbContextOptions options) : base(options) { }
-    public DbSet<Pizza> Pizzas { get; set; }
+    public DbSet<Pizza> Pizzas { get; set; } = null!;
 
     protected override void OnModelCreating (ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
This [tutorial](https://learn.microsoft.com/en-in/training/modules/build-web-api-minimal-spa/5-exercise-create-api) from Microsoft Docs tells us to clone this repo in one of its steps. After cloning the repo, the following warning popped up: 

![warning image](https://user-images.githubusercontent.com/89210438/222688311-f5cce62a-7fa5-4f21-850a-5fbb2642e6c9.png)

Setting the value to `null!` fixed the issue.
